### PR TITLE
Upgrade dependencies and add Go 1.19 as target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        go: ['1.18', '1.17', '1.16']
+        go: ['1.19', '1.18', '1.17', '1.16']
         platform: [ubuntu-latest] # can not run in windows OS
     runs-on: ${{ matrix.platform }}
 

--- a/configor_test.go
+++ b/configor_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/BurntSushi/toml"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type Anonymous struct {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/Slijkhuis/configor
 go 1.16
 
 require (
-	github.com/BurntSushi/toml v0.3.1
-	gopkg.in/yaml.v2 v2.2.2
+	github.com/BurntSushi/toml v1.2.0
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v1.2.0 h1:Rt8g24XnyGTyglgET/PRUNlrUeu9F5L+7FilkXfZgs0=
+github.com/BurntSushi/toml v1.2.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
-gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package configor
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +15,7 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 // UnmatchedTomlKeysError errors are returned by the Load function when
@@ -127,7 +128,9 @@ func (c *Configor) processFile(config interface{}, file string, errorOnUnmatched
 	switch {
 	case strings.HasSuffix(file, ".yaml") || strings.HasSuffix(file, ".yml"):
 		if errorOnUnmatchedKeys {
-			return yaml.UnmarshalStrict(data, config)
+			decoder := yaml.NewDecoder(bytes.NewBuffer(data))
+			decoder.KnownFields(true)
+			return decoder.Decode(config)
 		}
 		return yaml.Unmarshal(data, config)
 	case strings.HasSuffix(file, ".toml"):
@@ -149,7 +152,9 @@ func (c *Configor) processFile(config interface{}, file string, errorOnUnmatched
 
 		var yamlError error
 		if errorOnUnmatchedKeys {
-			yamlError = yaml.UnmarshalStrict(data, config)
+			decoder := yaml.NewDecoder(bytes.NewBuffer(data))
+			decoder.KnownFields(true)
+			yamlError = decoder.Decode(config)
 		} else {
 			yamlError = yaml.Unmarshal(data, config)
 		}


### PR DESCRIPTION
The `gopkg.in/yaml.v2` dependency triggers some security warnings. As far as I can see there's no feasible attack surface unless the config files are user generated input. However, you never know how this library is being used in the wild.